### PR TITLE
Update instructions how to setup

### DIFF
--- a/README
+++ b/README
@@ -2,11 +2,11 @@
 
     $ cd ~/scheme # Or wherever you keep your Scheme libraries
 
-    $ git clone git://github.com/dharmatech/surfage.git
+    $ git clone git@github.com:dharmatech/surfage.git
 
-    $ git clone git://github.com/dharmatech/dharmalab.git
+    $ git clone git@github.com:dharmatech/dharmalab.git
 
-    $ git clone git://github.com/dharmatech/mpl.git
+    $ git clone git@github.com:dharmatech/mpl.git
 
 * Running the unit tests
 


### PR DESCRIPTION
Github does not support `git://...` links. See https://github.blog/2021-09-01-improving-git-protocol-security-github/ Changed to fix this.